### PR TITLE
Fix check which ensures either we're using .NET Core version of Azure…

### DIFF
--- a/blockchain-workbench/scripts/troubleshooting/collectBlockchainWorkbenchTroubleshooting.ps1
+++ b/blockchain-workbench/scripts/troubleshooting/collectBlockchainWorkbenchTroubleshooting.ps1
@@ -434,7 +434,7 @@ if ((Get-Command "Login-AzureRmAccount" -errorAction SilentlyContinue) -eq $null
 }
 
 $rmWebApp = Get-Command "Get-AzureRmWebApp"
-if ($rmWebApp.Source -ne "AzureRM.Websites.Netcore" -or ($rmWebApp.Source -ne "AzureRM.Websites.Netcore" -and $rmWebApp.Version.Major -lt 5))
+if ($rmWebApp.Source -ne "AzureRM.Websites.Netcore" -and $rmWebApp.Version.Major -lt 5)
 {
     throw "The required version of the Azure Powershell cmdlets was not detected. We recommend that you follow the 
     instructions on https://www.powershellgallery.com/packages/AzureRM/6.0.1 to update to a compatible version. Or,

--- a/blockchain-workbench/scripts/troubleshooting/readme.md
+++ b/blockchain-workbench/scripts/troubleshooting/readme.md
@@ -15,7 +15,7 @@ Collects logs and metrics from an Azure Blockchain Workbench instance for
 troubleshooting. This script will prompt for Azure authentication if you
 are not already logged in.
 
-> NOTE: If you don't have the latest Azure Powershell installed on your machine, we recommend that you use the MSI installer to get the latest at https://github.com/Azure/azure-powershell/releases. Or, run this script using Azure Cloud shell at https://shell.azure.com.
+> NOTE: If you don't have the latest Azure Powershell installed on your machine, we recommend that you use the MSI installer to get the latest at https://github.com/Azure/azure-powershell/releases. This script currently doest not work on Azure Cloud shell.
 
 PARAMETER SubscriptionID
 ------------------------

--- a/blockchain-workbench/scripts/upgrade/azureBlockchainWorkbenchUpgradeTov1_2_0.ps1
+++ b/blockchain-workbench/scripts/upgrade/azureBlockchainWorkbenchUpgradeTov1_2_0.ps1
@@ -54,7 +54,7 @@ if ((Get-Command "Login-AzureRmAccount" -errorAction SilentlyContinue) -eq $null
 
 # AzureRM.Websites v5.0 or greater is required for support for upgrading Docker containers
 $rmWebApp = Get-Command "Get-AzureRmWebApp"
-if ($rmWebApp.Source -ne "AzureRM.Websites.Netcore" -or ($rmWebApp.Source -ne "AzureRM.Websites.Netcore" -and $rmWebApp.Version.Major -lt 5))
+if ($rmWebApp.Source -ne "AzureRM.Websites.Netcore" -and $rmWebApp.Version.Major -lt 5)
 {
     throw "The required version of the Azure Powershell cmdlets was not detected. We recommend that you follow the
     instructions on https://www.powershellgallery.com/packages/AzureRM/6.0.1 to update to a compatible version. Or,


### PR DESCRIPTION
…RmWebApp or we have version >= 5; also fixed readme to indicate troubleshooting script doesn't work on cloud shell at the moment

## Purpose
This change fixes a check which ensures the powershell script is either running on .NETCore version of Azure-RmWebApp or otherwise its version is >= 5. It also fixes the readme file to state that the current version of troubleshooting script doesn't work in Azure Cloud Shell.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x ] Documentation content changes
[ ] Other... Please describe:
```