### PR TITLE
Problems with file paths under windows for 'corda-local-network' service

### DIFF
--- a/blockchain-development-kit/accelerators/corda/service-bus-integration/corda-local-network/src/main/kotlin/net/corda/workbench/cordaNetwork/tasks/DeployCordaAppTask.kt
+++ b/blockchain-development-kit/accelerators/corda/service-bus-integration/corda-local-network/src/main/kotlin/net/corda/workbench/cordaNetwork/tasks/DeployCordaAppTask.kt
@@ -4,6 +4,7 @@ import net.corda.workbench.commons.taskManager.ExecutionContext
 import net.corda.workbench.commons.taskManager.NodesTask
 import net.corda.workbench.commons.taskManager.TaskContext
 import java.io.File
+import java.nio.file.Paths
 
 /**
  * Deploys the supplies app to all nodes, overwriting any existing
@@ -14,8 +15,11 @@ class DeployCordaAppTask(ctx: TaskContext, private val cordapp: File) : NodesTas
     override fun exec(executionContext: ExecutionContext) {
         for (f in nodesIter()) {
             executionContext.messageStream.invoke("Deploying cordapp ${cordapp.name} to ${f.name}")
-            val target = "$f/cordapps/${cordapp.name}"
-            cordapp.copyTo(File(target), true)
+            val target = Paths.get(f.toString(), "cordapps", cordapp.name)
+                    .normalize()
+                    .toAbsolutePath()
+                    .toFile()
+            cordapp.copyTo(target, true)
         }
     }
 }

--- a/blockchain-development-kit/accelerators/corda/service-bus-integration/corda-local-network/src/main/kotlin/net/corda/workbench/cordaNetwork/tasks/NodeCertificateTask.kt
+++ b/blockchain-development-kit/accelerators/corda/service-bus-integration/corda-local-network/src/main/kotlin/net/corda/workbench/cordaNetwork/tasks/NodeCertificateTask.kt
@@ -4,6 +4,7 @@ import net.corda.workbench.commons.taskManager.DataTask
 import net.corda.workbench.commons.taskManager.ExecutionContext
 import net.corda.workbench.commons.taskManager.TaskContext
 import java.io.FileInputStream
+import java.nio.file.Paths
 import java.security.KeyStore
 import java.security.PrivateKey
 import java.util.Base64
@@ -18,7 +19,9 @@ class NodeCertificateTask(val ctx: TaskContext,
 
     override fun exec(executionContext: ExecutionContext): String {
 
-        val fis = FileInputStream(ctx.workingDir + "/" + standardiseNodeName(nodeName) + "/certificates/nodekeystore.jks")
+        val keystorePath = Paths.get(ctx.workingDir , standardiseNodeName(nodeName) , "certificates" , "nodekeystore.jks")
+
+        val fis = FileInputStream(keystorePath.toFile())
 
         val keystore = KeyStore.getInstance(KeyStore.getDefaultType())
         val password = "cordacadevpass"

--- a/blockchain-development-kit/accelerators/corda/service-bus-integration/corda-local-network/src/main/kotlin/net/corda/workbench/cordaNetwork/tasks/NodeConfigTask.kt
+++ b/blockchain-development-kit/accelerators/corda/service-bus-integration/corda-local-network/src/main/kotlin/net/corda/workbench/cordaNetwork/tasks/NodeConfigTask.kt
@@ -4,6 +4,7 @@ import com.typesafe.config.ConfigFactory
 import net.corda.workbench.commons.taskManager.DataTask
 import net.corda.workbench.commons.taskManager.ExecutionContext
 import net.corda.workbench.commons.taskManager.TaskContext
+import java.nio.file.Paths
 
 /**
  * A Data task which reads values from the node config
@@ -14,7 +15,9 @@ class NodeConfigTask(val ctx: TaskContext,
     override fun exec(executionContext: ExecutionContext): Config {
         synchronized("NodeConfigTask") {
             ConfigFactory.invalidateCaches()
-            System.setProperty("config.file", ctx.workingDir + "/" + standardiseNodeName(nodeName) + "/node.conf")
+
+            val nodeConfFile = Paths.get(ctx.workingDir, standardiseNodeName(nodeName), "node.conf").normalize().toFile()
+            System.setProperty("config.file", nodeConfFile.absolutePath)
             val config = ConfigFactory.load()
 
             val port = config.getString("rpcSettings.address").split(":")[1].toInt()

--- a/blockchain-development-kit/accelerators/corda/service-bus-integration/corda-local-network/src/main/kotlin/net/corda/workbench/cordaNetwork/tasks/RealContext.kt
+++ b/blockchain-development-kit/accelerators/corda/service-bus-integration/corda-local-network/src/main/kotlin/net/corda/workbench/cordaNetwork/tasks/RealContext.kt
@@ -2,6 +2,7 @@ package net.corda.workbench.cordaNetwork.tasks
 
 import net.corda.workbench.commons.taskManager.TaskContext
 import java.io.File
+import java.nio.file.Paths
 
 class RealContext(override val networkName: String) : TaskContext {
     private val dataDir: String
@@ -10,7 +11,10 @@ class RealContext(override val networkName: String) : TaskContext {
         if (System.getProperty("datadir") != null) {
             dataDir = System.getProperty("datadir") as String
         } else {
-            dataDir = System.getProperty("user.home") + "/.corda-local-network"
+            dataDir = Paths.get(System.getProperty("user.home"), ".corda-local-network")
+                    .toFile()
+                    .absolutePath
+
         }
     }
 

--- a/blockchain-development-kit/accelerators/corda/service-bus-integration/corda-local-network/src/test/kotlin/net/corda/workbench/cordaNetwork/tasks/ConfigBuilderTaskSpec.kt
+++ b/blockchain-development-kit/accelerators/corda/service-bus-integration/corda-local-network/src/test/kotlin/net/corda/workbench/cordaNetwork/tasks/ConfigBuilderTaskSpec.kt
@@ -2,6 +2,8 @@ package net.corda.workbench.cordaNetwork.tasks
 
 import com.natpryce.hamkrest.assertion.assert
 import com.natpryce.hamkrest.equalTo
+import net.corda.workbench.commons.event.EventStore
+import net.corda.workbench.commons.event.FileEventStore
 import net.corda.workbench.commons.taskManager.TestContext
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
@@ -19,7 +21,8 @@ object ConfigBuilderTaskSpec : Spek({
 
         it("should build a simple Alice & Bob network") {
             val ctx = TestContext()
-            val registry = Registry().store(ctx)
+            val registry = Registry().store(ctx).store(FileEventStore())
+
             val task = ConfigBuilderTask(registry, listOf("O=Notary,L=London,C=GB",
                     "O=Alice,L=New York,C=US",
                     "O=Bob,L=Paris,C=FR"))

--- a/blockchain-development-kit/accelerators/corda/service-bus-integration/corda-local-network/src/test/kotlin/net/corda/workbench/cordaNetwork/tasks/NodeConfigTaskSpec.kt
+++ b/blockchain-development-kit/accelerators/corda/service-bus-integration/corda-local-network/src/test/kotlin/net/corda/workbench/cordaNetwork/tasks/NodeConfigTaskSpec.kt
@@ -2,6 +2,7 @@ package net.corda.workbench.cordaNetwork.tasks
 
 import com.natpryce.hamkrest.assertion.assert
 import com.natpryce.hamkrest.equalTo
+import net.corda.workbench.commons.event.FileEventStore
 import net.corda.workbench.commons.registry.Registry
 import net.corda.workbench.commons.taskManager.TestContext
 import org.jetbrains.spek.api.Spek
@@ -21,7 +22,7 @@ object NodeConfigTaskSpec : Spek({
 
         beforeGroup {
             File(ctx.workingDir).deleteRecursively()
-            val registry = Registry().store(ctx)
+            val registry = Registry().store(ctx).store(FileEventStore())
 
 
             // comment this out to speed up local tests.


### PR DESCRIPTION
## Purpose
Standardising on 'java.nio.file.Paths' for portability across platforms. Windows user have been experiencing problems due to mix of unix & windows path separators

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

* Test the code
Changes only affect the 'corda-local-network' service

Unit tests (./gradlew test) are flaky due to timing issues, but should at least have not regressed.

For manual testing run though the steps in the 'QuickStart.md'  

