### PR TITLE
Fixed solidity 0.5.0 compile errors.

### DIFF
--- a/blockchain-workbench/application-and-smart-contract-samples/asset-transfer/ethereum/AssetTransfer.sol
+++ b/blockchain-workbench/application-and-smart-contract-samples/asset-transfer/ethereum/AssetTransfer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity >=0.4.25 <0.6.0;
 
 contract AssetTransfer
 {
@@ -13,7 +13,7 @@ contract AssetTransfer
     address public InstanceInspector;
     address public InstanceAppraiser;
 
-    constructor(string description, uint256 price) public
+    constructor(string memory description, uint256 price) public
     {
         InstanceOwner = msg.sender;
         AskingPrice = price;
@@ -31,7 +31,7 @@ contract AssetTransfer
         State = StateType.Terminated;
     }
 
-    function Modify(string description, uint256 price) public
+    function Modify(string memory description, uint256 price) public
     {
         if (State != StateType.Active)
         {
@@ -48,7 +48,7 @@ contract AssetTransfer
 
     function MakeOffer(address inspector, address appraiser, uint256 offerPrice) public
     {
-        if (inspector == 0x0 || appraiser == 0x0 || offerPrice == 0)
+        if (inspector == 0x0000000000000000000000000000000000000000 || appraiser == 0x0000000000000000000000000000000000000000 || offerPrice == 0)
         {
             revert();
         }
@@ -94,7 +94,7 @@ contract AssetTransfer
             revert();
         }
 
-        InstanceBuyer = 0x0;
+        InstanceBuyer = 0x0000000000000000000000000000000000000000;
         State = StateType.Active;
     }
 
@@ -168,7 +168,7 @@ contract AssetTransfer
             revert();
         }
 
-        InstanceBuyer = 0x0;
+        InstanceBuyer = 0x0000000000000000000000000000000000000000;
         OfferPrice = 0;
         State = StateType.Active;
     }

--- a/blockchain-workbench/application-and-smart-contract-samples/basic-provenance/ethereum/BasicProvenance.sol
+++ b/blockchain-workbench/application-and-smart-contract-samples/basic-provenance/ethereum/BasicProvenance.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity >=0.4.25 <0.6.0;
 
 contract BasicProvenance
 {
@@ -48,6 +48,6 @@ contract BasicProvenance
 
         State = StateType.Completed;
         PreviousCounterparty = Counterparty;
-        Counterparty = 0x0;
+        Counterparty = 0x0000000000000000000000000000000000000000;
     }
 }

--- a/blockchain-workbench/application-and-smart-contract-samples/defective-component-counter/ethereum/DefectiveComponentCounter.sol
+++ b/blockchain-workbench/application-and-smart-contract-samples/defective-component-counter/ethereum/DefectiveComponentCounter.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity >=0.4.25 <0.6.0;
 
 contract DefectiveComponentCounter {
 
@@ -12,7 +12,7 @@ contract DefectiveComponentCounter {
     int public Total;
 
     // constructor function
-    constructor(int[12] defectiveComponentsCount) public
+    constructor(int[12] memory defectiveComponentsCount) public
     {
         Manufacturer = msg.sender;
         DefectiveComponentsCount = defectiveComponentsCount;
@@ -38,7 +38,7 @@ contract DefectiveComponentCounter {
     }
 
     // add the required getter function for array DefectiveComponentsCount
-    function GetDefectiveComponentsCount() public constant returns (int[12]) {
+    function GetDefectiveComponentsCount() public view returns (int[12] memory) {
         return DefectiveComponentsCount;
     }
 }

--- a/blockchain-workbench/application-and-smart-contract-samples/digital-locker/ethereum/DigitalLocker.sol
+++ b/blockchain-workbench/application-and-smart-contract-samples/digital-locker/ethereum/DigitalLocker.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity >=0.4.25 <0.6.0;
 
 contract DigitalLocker
 {
@@ -16,7 +16,7 @@ contract DigitalLocker
     string public RejectionReason;
     StateType public State;
 
-    constructor(string lockerFriendlyName, address bankAgent) public
+    constructor(string memory lockerFriendlyName, address bankAgent) public
     {
         Owner = msg.sender;
         LockerFriendlyName = lockerFriendlyName;
@@ -31,7 +31,7 @@ contract DigitalLocker
         /* Need to update, likely with registry to confirm sender is agent
         Also need to add a function to re-assign the agent.
         */
-     if (Owner == msg.sender)
+        if (Owner == msg.sender)
         {
             revert();
         }
@@ -41,9 +41,9 @@ contract DigitalLocker
         State = StateType.DocumentReview;
     }
 
-    function RejectApplication(string rejectionReason) public
+    function RejectApplication(string memory rejectionReason) public
     {
-     if (BankAgent != msg.sender)
+        if (BankAgent != msg.sender)
         {
             revert();
         }
@@ -53,19 +53,19 @@ contract DigitalLocker
         State = StateType.DocumentReview;
     }
 
-    function UploadDocuments(string lockerIdentifier, string image) public
+    function UploadDocuments(string memory lockerIdentifier, string memory image) public
     {
-         if (BankAgent != msg.sender)
+        if (BankAgent != msg.sender)
         {
             revert();
         }
-            LockerStatus = "Approved";
-            Image = image;
-            LockerIdentifier = lockerIdentifier;
-            State = StateType.AvailableToShare;
+        LockerStatus = "Approved";
+        Image = image;
+        LockerIdentifier = lockerIdentifier;
+        State = StateType.AvailableToShare;
     }
 
-    function ShareWithThirdParty(address thirdPartyRequestor, string expirationDate, string intendedPurpose) public
+    function ShareWithThirdParty(address thirdPartyRequestor, string memory expirationDate, string memory intendedPurpose) public
     {
         if (Owner != msg.sender)
         {
@@ -75,7 +75,7 @@ contract DigitalLocker
         ThirdPartyRequestor = thirdPartyRequestor;
         CurrentAuthorizedUser = ThirdPartyRequestor;
 
-        LockerStatus ="Shared" ;
+        LockerStatus = "Shared";
         IntendedPurpose = intendedPurpose;
         ExpirationDate = expirationDate;
         State = StateType.SharingWithThirdParty;
@@ -98,12 +98,12 @@ contract DigitalLocker
         {
             revert();
         }
-        LockerStatus ="Available";
-        CurrentAuthorizedUser=0x0;
+        LockerStatus = "Available";
+        CurrentAuthorizedUser = 0x0000000000000000000000000000000000000000;
         State = StateType.AvailableToShare;
     }
 
-    function RequestLockerAccess(string intendedPurpose) public
+    function RequestLockerAccess(string memory intendedPurpose) public
     {
         if (Owner == msg.sender)
         {
@@ -111,7 +111,7 @@ contract DigitalLocker
         }
 
         ThirdPartyRequestor = msg.sender;
-        IntendedPurpose=intendedPurpose;
+        IntendedPurpose = intendedPurpose;
         State = StateType.SharingRequestPending;
     }
 
@@ -122,10 +122,10 @@ contract DigitalLocker
         {
             revert();
         }
-        LockerStatus ="Available";
-        ThirdPartyRequestor = 0x0;
-        CurrentAuthorizedUser = 0x0;
-        IntendedPurpose="";
+        LockerStatus = "Available";
+        ThirdPartyRequestor = 0x0000000000000000000000000000000000000000;
+        CurrentAuthorizedUser = 0x0000000000000000000000000000000000000000;
+        IntendedPurpose = "";
         State = StateType.AvailableToShare;
     }
     
@@ -135,8 +135,8 @@ contract DigitalLocker
         {
             revert();
         }
-        LockerStatus ="Available";
-        CurrentAuthorizedUser=0x0;
+        LockerStatus = "Available";
+        CurrentAuthorizedUser = 0x0000000000000000000000000000000000000000;
         State = StateType.AvailableToShare;
     }
 
@@ -146,7 +146,7 @@ contract DigitalLocker
         {
             revert();
         }
-        CurrentAuthorizedUser=0x0;
+        CurrentAuthorizedUser = 0x0000000000000000000000000000000000000000;
         State = StateType.Terminated;
     }
 }

--- a/blockchain-workbench/application-and-smart-contract-samples/frequent-flyer-rewards-calculator/ethereum/FrequentFlyerRewardsCalculator.sol
+++ b/blockchain-workbench/application-and-smart-contract-samples/frequent-flyer-rewards-calculator/ethereum/FrequentFlyerRewardsCalculator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity >=0.4.25 <0.6.0;
 
 contract FrequentFlyerRewardsCalculator
 {
@@ -26,7 +26,7 @@ contract FrequentFlyerRewardsCalculator
     }
 
     // call this function to add miles
-    function AddMiles(int[] miles) public
+    function AddMiles(int[] memory miles) public
     {
         if (Flyer != msg.sender)
         {
@@ -54,7 +54,7 @@ contract FrequentFlyerRewardsCalculator
         }
     }
 
-    function GetMiles() public constant returns (uint[]) {
+    function GetMiles() public view returns (uint[] memory) {
         return Miles;
     }
 }

--- a/blockchain-workbench/application-and-smart-contract-samples/hello-blockchain/HelloBlockchain.sol
+++ b/blockchain-workbench/application-and-smart-contract-samples/hello-blockchain/HelloBlockchain.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity >=0.4.25 <0.6.0;
 
 contract HelloBlockchain
 {
@@ -14,7 +14,7 @@ contract HelloBlockchain
     string public ResponseMessage;
 
     // constructor function
-    constructor(string message) public
+    constructor(string memory message) public
     {
         Requestor = msg.sender;
         RequestMessage = message;
@@ -22,7 +22,7 @@ contract HelloBlockchain
     }
 
     // call this function to send a request
-    function SendRequest(string requestMessage) public
+    function SendRequest(string memory requestMessage) public
     {
         if (Requestor != msg.sender)
         {
@@ -34,7 +34,7 @@ contract HelloBlockchain
     }
 
     // call this function to send a response
-    function SendResponse(string responseMessage) public
+    function SendResponse(string memory responseMessage) public
     {
         Responder = msg.sender;
 

--- a/blockchain-workbench/application-and-smart-contract-samples/refrigerated-transportation/ethereum/RefrigeratedTransportation.sol
+++ b/blockchain-workbench/application-and-smart-contract-samples/refrigerated-transportation/ethereum/RefrigeratedTransportation.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity >=0.4.25 <0.6.0;
 
 contract RefrigeratedTransportation
 {
@@ -40,7 +40,7 @@ contract RefrigeratedTransportation
         MinTemperature = minTemperature;
         MaxTemperature = maxTemperature;
         State = StateType.Created;
-        ComplianceDetail = 'N/A';
+        ComplianceDetail = "N/A";
     }
 
     function IngestTelemetry(int humidity, int temperature, int timestamp) public
@@ -69,14 +69,14 @@ contract RefrigeratedTransportation
         {
             ComplianceSensorType = SensorType.Humidity;
             ComplianceSensorReading = humidity;
-            ComplianceDetail = 'Humidity value out of range.';
+            ComplianceDetail = "Humidity value out of range.";
             ComplianceStatus = false;
         }
         else if (temperature > MaxTemperature || temperature < MinTemperature)
         {
             ComplianceSensorType = SensorType.Temperature;
             ComplianceSensorReading = temperature;
-            ComplianceDetail = 'Temperature value out of range.';
+            ComplianceDetail = "Temperature value out of range.";
             ComplianceStatus = false;
         }
 
@@ -140,6 +140,6 @@ contract RefrigeratedTransportation
 
         State = StateType.Completed;
         PreviousCounterparty = Counterparty;
-        Counterparty = 0x0;
+        Counterparty = 0x0000000000000000000000000000000000000000;
     }
 }

--- a/blockchain-workbench/application-and-smart-contract-samples/refrigerated-transportation/ethereum/RefrigeratedTransportationWithTime.sol
+++ b/blockchain-workbench/application-and-smart-contract-samples/refrigerated-transportation/ethereum/RefrigeratedTransportationWithTime.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity >=0.4.25 <0.6.0;
 
 contract RefrigeratedTransportationWithTime
 {
@@ -40,7 +40,7 @@ contract RefrigeratedTransportationWithTime
         MinTemperature = minTemperature;
         MaxTemperature = maxTemperature;
         State = StateType.Created;
-        ComplianceDetail = 'N/A';
+        ComplianceDetail = "N/A";
     }
 
     function IngestTelemetry(int humidity, int temperature, uint timestamp) public
@@ -58,14 +58,14 @@ contract RefrigeratedTransportationWithTime
         {
             ComplianceSensorType = SensorType.Humidity;
             ComplianceSensorReading = humidity;
-            ComplianceDetail = 'Humidity value out of range.';
+            ComplianceDetail = "Humidity value out of range.";
             ComplianceStatus = false;
         }
         else if (temperature > MaxTemperature || temperature < MinTemperature)
         {
             ComplianceSensorType = SensorType.Temperature;
             ComplianceSensorReading = temperature;
-            ComplianceDetail = 'Temperature value out of range.';
+            ComplianceDetail = "Temperature value out of range.";
             ComplianceStatus = false;
         }
 
@@ -105,6 +105,6 @@ contract RefrigeratedTransportationWithTime
 
         State = StateType.Completed;
         PreviousCounterparty = Counterparty;
-        Counterparty = 0x0;
+        Counterparty = 0x0000000000000000000000000000000000000000;
     }
 }

--- a/blockchain-workbench/application-and-smart-contract-samples/room-thermostat/ethereum/RoomThermostat.sol
+++ b/blockchain-workbench/application-and-smart-contract-samples/room-thermostat/ethereum/RoomThermostat.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity >=0.4.25 <0.6.0;
 
 contract RoomThermostat
 {

--- a/blockchain-workbench/application-and-smart-contract-samples/simple-marketplace/ethereum/SimpleMarketplace.sol
+++ b/blockchain-workbench/application-and-smart-contract-samples/simple-marketplace/ethereum/SimpleMarketplace.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.25;
+pragma solidity >=0.4.25 <0.6.0;
 
 contract SimpleMarketplace
 {
@@ -16,7 +16,7 @@ contract SimpleMarketplace
     address public InstanceBuyer;
     int public OfferPrice;
 
-    constructor(string description, int price) public
+    constructor(string memory description, int price) public
     {
         InstanceOwner = msg.sender;
         AskingPrice = price;
@@ -58,7 +58,7 @@ contract SimpleMarketplace
             revert();
         }
 
-        InstanceBuyer = 0x0;
+        InstanceBuyer = 0x0000000000000000000000000000000000000000;
         State = StateType.ItemAvailable;
     }
 


### PR DESCRIPTION
## Purpose
Fixed the solidity samples so that they work with the latest version of Truffle which supports solidity version 0.5.0. In some cases this required adding in keywords that are now enforced, like constant => view/pure  or adding `memory` to temporary variables.
I also fixed some basic linting errors around.

I did not modify the PingPong sample, as the linter was throwing errors about function parameters being modified e.g. `currentPingPongTimes = currentPingPongTimes - 1;`. I was unsure what the sample was trying to do.

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```
No breaking changes, as the pragma declaration says to support compilers from the current 0.4.25

## Pull Request Type
```
[ ] Bugfix
[ ] Feature
[X] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

