### PR TITLE
Bump BlockScout version & deps and enable 18.04 support 

### DIFF
--- a/ledger/template/ethereum-on-azure/technology-samples/blockscout/install_blockscout.sh
+++ b/ledger/template/ethereum-on-azure/technology-samples/blockscout/install_blockscout.sh
@@ -32,7 +32,7 @@ sudo apt-get -y install esl-erlang=1:21.1.1-1
 sudo apt-get -y install elixir=1.8.1-2
 
 # gcc, make and build-essential Install
-sudo apt-get install build-essential make automake libtool inotify-tools autoconf libgmp-dev gcc
+sudo apt-get -y install build-essential make automake libtool inotify-tools autoconf libgmp-dev gcc
 
 
 # nginx Install

--- a/ledger/template/ethereum-on-azure/technology-samples/blockscout/install_blockscout.sh
+++ b/ledger/template/ethereum-on-azure/technology-samples/blockscout/install_blockscout.sh
@@ -32,7 +32,7 @@ sudo apt-get -y install esl-erlang=1:21.1.1-1
 sudo apt-get -y install elixir=1.8.1-2
 
 # gcc, make and build-essential Install
-sudo apt-get install build-essential make automake libtool inotify-tools autoconf libgmpv4-dev gcc
+sudo apt-get install build-essential make automake libtool inotify-tools autoconf libgmp-dev gcc
 
 
 # nginx Install

--- a/ledger/template/ethereum-on-azure/technology-samples/blockscout/install_blockscout.sh
+++ b/ledger/template/ethereum-on-azure/technology-samples/blockscout/install_blockscout.sh
@@ -26,14 +26,14 @@ WEBSOCKET_ENDPOINT=$2
 DATABASE_PW=$3
 
 # Erlang VM & Elixir Install
-wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && sudo dpkg -i erlang-solutions_1.0_all.deb
+wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb
+sudo dpkg -i erlang-solutions_1.0_all.deb
 sudo apt-get update
-sudo apt-get -y install esl-erlang=1:21.1.1-1
-sudo apt-get -y install elixir=1.8.1-2
+sudo apt-get -y install esl-erlang
+sudo apt-get -y install elixir
 
 # gcc, make and build-essential Install
 sudo apt-get -y install build-essential make automake libtool inotify-tools autoconf libgmp-dev gcc
-
 
 # nginx Install
 sudo apt-get -y install nginx && sudo ufw allow 'Nginx HTTP'
@@ -44,8 +44,8 @@ sudo apt-get -y install nodejs
 sudo ln -s /usr/bin/nodejs /usr/bin/node
 
 # PostgreSQL Install
-echo 'deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main' sudo tee -a /etc/apt/sources.list.d/pgdg.list
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" >> /etc/apt/sources.list.d/pgdg.list'
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc -O - | sudo apt-key add -
 sudo apt-get update && sudo apt-get -y install postgresql
 sudo apt-get update && sudo apt-get -y install postgresql-client
 
@@ -56,7 +56,7 @@ sudo -u postgres psql -U postgres -d postgres -c "alter user postgres with passw
 sudo apt-get install -y git
 sudo git clone https://github.com/poanetwork/blockscout.git && echo "cloned"
 cd blockscout
-sudo git checkout v1.3.9-beta && echo "checked out"; cd -
+sudo git checkout master && echo "checked out"; cd -
 sudo chmod -R a+x blockscout && echo "permissions granted"
 
 

--- a/ledger/template/ethereum-on-azure/technology-samples/blockscout/install_blockscout.sh
+++ b/ledger/template/ethereum-on-azure/technology-samples/blockscout/install_blockscout.sh
@@ -29,12 +29,11 @@ DATABASE_PW=$3
 wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && sudo dpkg -i erlang-solutions_1.0_all.deb
 sudo apt-get update
 sudo apt-get -y install esl-erlang=1:21.1.1-1
-sudo apt-get -y install elixir=1.7.4-1
+sudo apt-get -y install elixir=1.8.1-2
 
 # gcc, make and build-essential Install
-sudo apt-get install make
-sudo apt-get -y install gcc
-sudo apt-get -y install build-essential
+sudo apt-get install build-essential make automake libtool inotify-tools autoconf libgmpv4-dev gcc
+
 
 # nginx Install
 sudo apt-get -y install nginx && sudo ufw allow 'Nginx HTTP'
@@ -57,7 +56,7 @@ sudo -u postgres psql -U postgres -d postgres -c "alter user postgres with passw
 sudo apt-get install -y git
 sudo git clone https://github.com/poanetwork/blockscout.git && echo "cloned"
 cd blockscout
-sudo git checkout 53ea60c3 && echo "checked out"; cd -
+sudo git checkout v1.3.9-beta && echo "checked out"; cd -
 sudo chmod -R a+x blockscout && echo "permissions granted"
 
 
@@ -196,7 +195,7 @@ echo "
 	Environment=MIX_ENV=prod
 	Environment=LANG=en_US.UTF-8
 	WorkingDirectory=/home/$USER/blockscout
-	ExecStart=/usr/local/bin/mix phx.server
+	ExecStart=/usr/bin/mix phx.server
 
 	[Install]
 	WantedBy=multi-user.target


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This change fixes a list of (known bugs) bugs that we discovered running blockscout in production on Azure.

**Changes:**
- bump blockscout and deps to a more stable plus recent version
- the installer supports 16.04 and 18.04 VMs now

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Follow the existing instructions on https://github.com/Azure-Samples/blockchain/tree/master/ledger/template/ethereum-on-azure/technology-samples/blockscout and adapt the changes to the installer contained in this pull request

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
- Open the explorer page.

## What to Check
Verify that the following are valid
- The explorer page opens and transactions are indexed.

## Other Information
<!-- Add any other helpful information that may be needed here. -->